### PR TITLE
ci: don't run bloat on scheduled runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,7 @@ jobs:
           key:
             bloat-${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
       - name: Run cargo bloat
+        if: ${{ github.event_name != 'schedule' }}
         # @todo For security, let's fork this into the OpenPoolProject/actions
         # folder - the original (this is a fork) no longer works because it uses
         # a 3rd parter server to cache builds that is no longer existant.


### PR DESCRIPTION
Addresses #648 - Bloat doesn't work when there is no ref to compare. There is probably a better way to fix this, but for now let's see how this works. 

This will likely fail if there is a manually triggered re-run, because again, there is no ref to compare to. I be